### PR TITLE
fix: change cdk stack name from prefix of CdkStack to earthdata-dashboard-maap

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -4,7 +4,7 @@ import * as cdk from '@aws-cdk/core';
 import { CdkStack } from '../lib/cdk-stack';
 
 const app = new cdk.App();
-new CdkStack(app, `CdkStack-${process.env.STAGE}`, {
+new CdkStack(app, `earthdata-dashboard-${process.env.STAGE}`, {
   /* If you don't specify 'env', this stack will be environment-agnostic.
    * Account/Region-dependent features and context lookups will not work,
    * but a single synthesized template can be deployed anywhere. */


### PR DESCRIPTION
This changes the CDK-generated stack name to a prefix more in-line with other deployed components.